### PR TITLE
Rename tzdb-gen executable to SwiftTZGenerator

### DIFF
--- a/.github/workflows/update-tzdb.yml
+++ b/.github/workflows/update-tzdb.yml
@@ -64,7 +64,7 @@ jobs:
       
       - name: Generate updated timezone data
         if: steps.check.outputs.changes_detected == 'true'
-        run: swift run tzdb-gen
+        run: swift run SwiftTZGenerator
       
       - name: Create Pull Request
         if: steps.check.outputs.changes_detected == 'true'
@@ -76,7 +76,7 @@ jobs:
           body: |
             This PR updates the timezone database based on changes in the IANA tzdb.
             
-            Changes were automatically detected and generated using the `tzdb-gen` tool.
+            Changes were automatically detected and generated using the `SwiftTZGenerator` tool.
             
             ### Changes
             <details>

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,7 @@ let package = Package(
         .visionOS(.v1)
     ],
     products: [
-        .library(name: "SwiftTZ", targets: ["SwiftTZ"]),
-        .executable(name: "tzdb-gen", targets: ["SwiftTZGenerator"]),
+        .library(name: "SwiftTZ", targets: ["SwiftTZ"])
     ],
     targets: [
         // Generator executable

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd SwiftTZ
 2. Run the generator to fetch the latest IANA Time Zone Database and generate the `TimeZoneIdentifier.swift` file
 
 ```sh
-swift run tzdb-gen
+swift run SwiftTZGenerator
 ``` 
 
 ## Acknowledgments


### PR DESCRIPTION
- Remove separate executable product name while keeping target name consistent
- Update references in GitHub workflow and documentation
- No functional changes, purely naming consistency improvement